### PR TITLE
aider: Increment version number and push to TestPyPI after checking t…

### DIFF
--- a/.github/workflows/post-pr-merge.yaml
+++ b/.github/workflows/post-pr-merge.yaml
@@ -29,10 +29,33 @@ jobs:
           make sdist
           make wheel
           make test
+      - name: Check current version on TestPyPI
+        id: check_version
+        run: |
+          echo "Checking current version on TestPyPI..."
+          current_version=$(pip index versions your-package-name | grep -Po '(?<=\().*?(?=\))' | sort -V | tail -n 1)
+          echo "Current version on TestPyPI is $current_version"
+          IFS='.' read -ra VERSION_PARTS <<< "$current_version"
+          VERSION_PARTS[-1]=$((VERSION_PARTS[-1]+1))
+          new_version="${VERSION_PARTS[*]}"
+          echo "New version will be $new_version"
+          echo "new_version=$new_version" >> $GITHUB_ENV
+      - name: Update version file
+        run: |
+          echo "${{ env.new_version }}" > VERSION
+          cat VERSION
+      - name: Commit and push new version
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+          git add VERSION
+          git commit -m "Increment version number to ${{ env.new_version }}"
+          git push
       - name: Push to TestPyPI
+        if: github.ref == 'refs/heads/main'
         if: github.ref == 'refs/heads/main' # This ensures that PyPI upload only happens on main branch merges.  
         run: |
-            make upload-test TEST_PYPI_USER_AGENT=${{ secrets.TEST_PYPI_USER_AGENT }}
+            make upload-test TEST_PYPI_USER_AGENT=${{ secrets.TEST_PYPI_USER_AGENT }} VERSION=${{ env.new_version }}
             env:
               VERSION: ${{ needs.increment-version.outputs.new_version }}
       - name: Push to PyPI


### PR DESCRIPTION
…he current version in TestPyPI in `.github/workflows/post-pr-merge.yaml`.

# Aider chat conversation:

USER: Make `.github/workflows/post-pr-merge.yaml` check the current version in test PyPi and increment the file to the next highest number before pushing the test

ASSISTANT: To make the `.github/workflows/post-pr-merge.yaml` workflow check the current version in TestPyPI and increment the file to the next highest number before pushing the test, we need to add steps to the workflow that perform these actions. Here is the diff for the required changes:

```diff
--- .github/workflows/post-pr-merge.yaml
+++ .github/workflows/post-pr-merge.yaml
@@ ... @@
       - name: Build and test
         run: |
           pip install .
           make sdist
           make wheel
           make test
+      - name: Check current version on TestPyPI
+        id: check_version
+        run: |
+          echo "Checking current version on TestPyPI..."
+          current_version=$(pip index versions your-package-name | grep -Po '(?<=\().*?(?=\))' | sort -V | tail -n 1)
+          echo "Current version on TestPyPI is $current_version"
+          IFS='.' read -ra VERSION_PARTS <<< "$current_version"
+          VERSION_PARTS[-1]=$((VERSION_PARTS[-1]+1))
+          new_version="${VERSION_PARTS[*]}"
+          echo "New version will be $new_version"
+          echo "new_version=$new_version" >> $GITHUB_ENV
+      - name: Update version file
+        run: |
+          echo "${{ env.new_version }}" > VERSION
+          cat VERSION
+      - name: Commit and push new version
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+          git add VERSION
+          git commit -m "Increment version number to ${{ env.new_version }}"
+          git push
       - name: Push to TestPyPI
         if: github.ref == 'refs/heads/main'
         run: |
-            make upload-test TEST_PYPI_USER_AGENT=${{ secrets.TEST_PYPI_USER_AGENT }}
+            make upload-test TEST_PYPI_USER_AGENT=${{ secrets.TEST_PYPI_USER_AGENT }} VERSION=${{ env.new_version }}
```

Please note that you need to replace `your-package-name` with the actual name of your package as it appears on TestPyPI. This script assumes that the version numbers are in the format `MAJOR.MINOR.PATCH` and increments the `PATCH` number. If your versioning scheme is different, you will need to adjust the script accordingly.