### PR TITLE
aider: Removed redundant `if` condition in post-pr-merge.yaml file.

### DIFF
--- a/.github/workflows/post-pr-merge.yaml
+++ b/.github/workflows/post-pr-merge.yaml
@@ -52,7 +52,6 @@ jobs:
           git commit -m "Increment version number to ${{ env.new_version }}"
           git push
       - name: Push to TestPyPI
-        if: github.ref == 'refs/heads/main'
         if: github.ref == 'refs/heads/main' # This ensures that PyPI upload only happens on main branch merges.  
         run: |
             make upload-test TEST_PYPI_USER_AGENT=${{ secrets.TEST_PYPI_USER_AGENT }} VERSION=${{ env.new_version }}


### PR DESCRIPTION
# Aider chat conversation:

USER: I ran this command:

 act push

And got this output:

time="2024-03-30T17:48:34+11:00" level=info msg="Using docker host 'unix:///var/run/docker.sock', and daemon socket 'unix:///var/run/docker.sock'" level=warning msg= ⚠ You are using Apple M-series chip and you have not specified container architecture, you might encounter issues while running act. If so, try running it with '--container-architecture linux/amd64'. ⚠

Error: workflow is not valid. 'post-pr-merge.yaml': yaml: unmarshal errors:
  line 56: mapping key "if" already defined at line 55

ASSISTANT: The error message indicates that there is a duplicate `if` condition on lines 55 and 56 in the `post-pr-merge.yaml` file. This is causing the workflow file to be invalid. To fix this, we need to remove the duplicate `if` condition. Here is the diff for the required changes:

```diff
--- .github/workflows/post-pr-merge.yaml
+++ .github/workflows/post-pr-merge.yaml
@@ ... @@
       - name: Push to TestPyPI
-        if: github.ref == 'refs/heads/main'
         if: github.ref == 'refs/heads/main' # This ensures that PyPI upload only happens on main branch merges.
         run: |
             make upload-test TEST_PYPI_USER_AGENT=${{ secrets.TEST_PYPI_USER_AGENT }} VERSION=${{ env.new_version }}
             env:
               VERSION: ${{ needs.increment-version.outputs.new_version }}
       - name: Push to PyPI
```

This change removes the redundant `if` condition to ensure that the workflow file is valid.