### PR TITLE
aider: Update pip command to use TestPyPI index URL for checking the …

### DIFF
--- a/.github/workflows/post-pr-merge.yaml
+++ b/.github/workflows/post-pr-merge.yaml
@@ -34,7 +34,7 @@ jobs:
         id: check_version
         run: |
           echo "Checking current version on TestPyPI..."
-          current_version=$(pip index versions klingon-serial | grep -Po '(?<=\().*?(?=\))' | sort -V | tail -n 1)
+          current_version=$(pip index versions --index-url https://test.pypi.org/simple/ klingon-serial | grep -Po '(?<=\().*?(?=\))' | sort -V | tail -n 1)
           echo "Current version on TestPyPI is $current_version"
           IFS='.' read -ra VERSION_PARTS <<< "$current_version"
           VERSION_PARTS[-1]=$((VERSION_PARTS[-1]+1))


### PR DESCRIPTION
…latest version.

# Aider chat conversation:

USER: pre-pr-merge
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

ASSISTANT: To update the GitHub Actions workflows to use Node.js 20, you need to specify the `node-version` for the `actions/checkout@v3` and `actions/setup-python@v3` actions. However, these actions themselves do not directly use Node.js in a way that requires specifying a Node.js version. The deprecation notice you've mentioned is likely for other Node.js-based actions or for workflows that explicitly use Node.js in their runs.

If you have any Node.js-based actions or steps that specify Node.js 16, you would update them to use Node.js 20. Since the provided workflows do not contain any Node.js version specifications, no changes are required for Node.js versioning.

If you have other workflows or steps that do use Node.js and need to be updated, please provide the relevant sections, and I will assist you with the necessary changes.

USER: Whe checking for latest version on test pypi the pip command isn't using the test pypi index

ASSISTANT: To fix the issue with checking the latest version on TestPyPI, we need to update the `pip index versions` command to use the TestPyPI index URL. Here is the diff for the required changes in the `.github/workflows/post-pr-merge.yaml` file:

```diff
--- .github/workflows/post-pr-merge.yaml
+++ .github/workflows/post-pr-merge.yaml
@@ ... @@
       - name: Check current version on TestPyPI
         id: check_version
         run: |
           echo "Checking current version on TestPyPI..."
-          current_version=$(pip index versions klingon-serial | grep -Po '(?<=\().*?(?=\))' | sort -V | tail -n 1)
+          current_version=$(pip index versions --index-url https://test.pypi.org/simple/ klingon-serial | grep -Po '(?<=\().*?(?=\))' | sort -V | tail -n 1)
           echo "Current version on TestPyPI is $current_version"
           IFS='.' read -ra VERSION_PARTS <<< "$current_version"
           VERSION_PARTS[-1]=$((VERSION_PARTS[-1]+1))
           new_version="${VERSION_PARTS[*]}"
           echo "New version will be $new_version"
           echo "new_version=$new_version" >> $GITHUB_ENV
```

This change adds the `--index-url https://test.pypi.org/simple/` option to the `pip index versions` command to specify the TestPyPI index URL.