### PR TITLE
aider: Update post-pr-merge workflow to push new version to the branc…

### DIFF
--- a/.github/workflows/post-pr-merge.yaml
+++ b/.github/workflows/post-pr-merge.yaml
@@ -51,7 +51,7 @@ jobs:
           git config --global user.name "GitHub Action"
           git add VERSION
           git commit -m "Increment version number to ${{ env.new_version }}"
-          git push
+          git push origin ${{ github.head_ref }}
       - name: Push to TestPyPI
         if: github.ref == 'refs/heads/main' # This ensures that PyPI upload only happens on main branch merges.  
         run: |


### PR DESCRIPTION
…h associated with the pull request.

# Aider chat conversation:

USER: Make the commit and push new version step push to the branch that the PR is coming from. ie. in this case it would be openfaas-container

ASSISTANT: To modify the `.github/workflows/post-pr-merge.yaml` workflow so that the "Commit and push new version" step pushes to the branch that the pull request is coming from, we need to extract the branch name from the `github.head_ref` context and use it in the `git push` command.

Here is the diff for the required changes:

```diff
--- .github/workflows/post-pr-merge.yaml
+++ .github/workflows/post-pr-merge.yaml
@@ ... @@
       - name: Commit and push new version
         run: |
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
           git add VERSION
           git commit -m "Increment version number to ${{ env.new_version }}"
-          git push
+          git push origin ${{ github.head_ref }}
```

This change will ensure that the new version is committed and pushed to the branch associated with the pull request, rather than always pushing to the `main` branch.