### PR TITLE
aider: Incremented version number to 0.1.10 and fixed git push error …

### DIFF
--- a/.github/workflows/post-pr-merge.yaml
+++ b/.github/workflows/post-pr-merge.yaml
@@ -51,7 +51,7 @@ jobs:
           git config --global user.name "GitHub Action"
           git add VERSION
           git commit -m "Increment version number to ${{ env.new_version }}"
-          git push origin ${{ github.head_ref }}
+          git push origin ${{ github.event.pull_request.head.ref }}
       - name: Push to TestPyPI
         if: github.ref == 'refs/heads/main' # This ensures that PyPI upload only happens on main branch merges.  
         run: |


### PR DESCRIPTION
…by using the correct branch name from the pull request event.

# Aider chat conversation:

USER: 0s
Run git config --global user.email "action@github.com"
  git config --global user.email "action@github.com"
  git config --global user.name "GitHub Action"
  git add VERSION
  git commit -m "Increment version number to 0.1.10"
  git push origin openfaas-container
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.12.2/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.12.2/x64/lib
    new_version: 0.1.10
[main 1573e98] Increment version number to 0.1.10
 1 file changed, 1 insertion(+), 1 deletion(-)
error: src refspec openfaas-container does not match any error: failed to push some refs to 'https://github.com/djh00t/module_klingon_serial' Error: Process completed with exit code 1.

ASSISTANT: The error message indicates that the `openfaas-container` branch does not exist or is not recognized in the context of the workflow run. This can happen if the branch name is not being correctly retrieved or if the workflow is not running in the context of a pull request event where `github.head_ref` would be set.

To fix this, we need to ensure that the branch name is correctly determined and used in the `git push` command. We can use the `github.event.pull_request.head.ref` context to get the source branch name for pull requests.

Here is the diff for the `.github/workflows/post-pr-merge.yaml` file to address this issue:

```diff
--- .github/workflows/post-pr-merge.yaml
+++ .github/workflows/post-pr-merge.yaml
@@ ... @@
       - name: Commit and push new version
         run: |
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
           git add VERSION
           git commit -m "Increment version number to ${{ env.new_version }}"
-          git push origin ${{ github.head_ref }}
+          git push origin ${{ github.event.pull_request.head.ref }}
```

This change will ensure that the workflow uses the correct branch name from the pull request event when attempting to push the commit. Make sure that this step only runs in the context of a pull request event to avoid issues when `github.event.pull_request.head.ref` is not available.