### PR TITLE
aider: Updated GitHub Actions to use Node.js 20 and latest versions o…

### DIFF
--- a/.github/workflows/openfaas-docker-build.yaml
+++ b/.github/workflows/openfaas-docker-build.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Ensure Docker is installed and running
       run: |
@@ -28,7 +28,7 @@ jobs:
       shell: bash
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
       with:
         install: true
         version: latest
@@ -38,7 +38,7 @@ jobs:
       id: buildx
 
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/openfaas-docker-build.yaml
+++ b/.github/workflows/openfaas-docker-build.yaml
@@ -1,9 +1,15 @@
 name: OpenFaaS Docker Build
 
 on:
-  push:
+  merge:
     branches:
       - main
+    paths:
+      - 'openfaas/**'
+      - '.github/workflows/openfaas-docker-build.yaml'
+  push:
+    branches:
+      - !main
     paths:
       - 'openfaas/**'
       - '.github/workflows/openfaas-docker-build.yaml'

--- a/.github/workflows/openfaas-docker-build.yaml
+++ b/.github/workflows/openfaas-docker-build.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'openfaas/**'
       - '.github/workflows/openfaas-docker-build.yaml'
+  
 
 jobs:
   build-and-push:

--- a/.github/workflows/openfaas-docker-build.yaml
+++ b/.github/workflows/openfaas-docker-build.yaml
@@ -1,15 +1,9 @@
 name: OpenFaaS Docker Build
 
 on:
-  merge:
-    branches:
-      - main
-    paths:
-      - 'openfaas/**'
-      - '.github/workflows/openfaas-docker-build.yaml'
   push:
     branches:
-      - !main
+      - main
     paths:
       - 'openfaas/**'
       - '.github/workflows/openfaas-docker-build.yaml'

--- a/.github/workflows/openfaas-docker-build.yaml
+++ b/.github/workflows/openfaas-docker-build.yaml
@@ -7,7 +7,10 @@ on:
     paths:
       - 'openfaas/**'
       - '.github/workflows/openfaas-docker-build.yaml'
-  
+  workflow_dispatch:
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   build-and-push:

--- a/.github/workflows/openfaas-docker-build.yaml
+++ b/.github/workflows/openfaas-docker-build.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'openfaas/**'
+      - '.github/workflows/openfaas-docker-build.yaml'
 
 jobs:
   build-and-push:

--- a/.github/workflows/pre-docker-build-pr.yaml
+++ b/.github/workflows/pre-docker-build-pr.yaml
@@ -1,0 +1,71 @@
+name: Pre Docker Build PR
+
+on:
+  push:
+    branches:
+      - '!main'
+    paths:
+      - 'openfaas/**'
+      - '.github/workflows/openfaas-docker-build.yaml'
+
+jobs:
+  prepare-version-pr:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install requests
+
+    - name: Calculate new release number
+      id: versioning
+      run: |
+        from build import fetch_latest_tag, increment_version
+        image_name = 'djh00t/klingon-serial'  # Replace with your actual image name
+        latest_tag = fetch_latest_tag(image_name)
+        new_version = increment_version(latest_tag, 'patch')  # Assuming we're doing a patch release
+        print(f"::set-output name=new_version::{new_version}")
+      shell: python
+
+    - name: Create or update PR with new release number
+      uses: peter-evans/create-pull-request@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: "Prepare for Docker build version ${{ steps.versioning.outputs.new_version }}"
+        title: "Docker Build Version ${{ steps.versioning.outputs.new_version }}"
+        body: |
+          ## Changelog
+          <!-- markdown-changelog-generator -->
+        branch: "release-${{ steps.versioning.outputs.new_version }}"
+        base: "main"
+        labels: "pre-release"
+        update-branch: true
+        title-regex: "Docker Build Version"
+        body-includes-regex: "markdown-changelog-generator"
+
+    - name: Ensure PR depends on this workflow
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const { context } = require('@actions/github');
+          const pull_number = context.payload.pull_request.number;
+          const workflow_id = 'pre-docker-build-pr.yaml';
+          await github.rest.actions.createWorkflowDispatch({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: workflow_id,
+            ref: context.ref,
+            inputs: {
+              pull_number: pull_number
+            }
+          });
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-pr-merge.yaml
+++ b/.github/workflows/pre-pr-merge.yaml
@@ -10,12 +10,13 @@ on:
       - 'Makefile'
       - 'setup.py'
       - 'requirements.txt'
+      - '!openfaas/**'
     branches:
       - main
   workflow_dispatch:
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   pre-pr-merge:


### PR DESCRIPTION
…f actions/checkout, docker/setup-buildx-action, and docker/login-action in .github/workflows/openfaas-docker-build.yaml.

# Aider chat conversation:

USER: build-and-push
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, docker/setup-buildx-action@v1, docker/login-action@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/. build-and-push
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, docker/setup-buildx-action@v1, docker/login-action@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/ build-and-push
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

ASSISTANT: To address the deprecation warnings and upgrade the GitHub Actions to use Node.js 20, I will update the `.github/workflows/openfaas-docker-build.yaml` file. Please add this file to the chat so I can make the necessary changes.

USER: I added these *read-write* files: .github/workflows/openfaas-docker-build.yaml

ASSISTANT: Here are the diffs for the necessary changes to `.github/workflows/openfaas-docker-build.yaml` to address the deprecation warnings and upgrade the GitHub Actions to use Node.js 20:

```diff
--- .github/workflows/openfaas-docker-build.yaml
+++ .github/workflows/openfaas-docker-build.yaml
@@ ... @@
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3

@@ ... @@
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
       with:
         install: true
         version: latest
         buildkitd-flags: --debug
         driver-opts: image=moby/buildkit:master
         use: true
       id: buildx

@@ ... @@
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
```

These changes update the versions of `actions/checkout`, `docker/setup-buildx-action`, and `docker/login-action` to their latest versions that support Node.js 20. Additionally, the `save-state` command is not used in the provided workflow file, so no changes are required for that deprecation.