### PR TITLE
aider: Include the commit string for each commit in the pull request'…

### DIFF
--- a/.github/workflows/openfaas-pre-docker-build-pr.yaml
+++ b/.github/workflows/openfaas-pre-docker-build-pr.yaml
@@ -51,9 +51,19 @@ jobs:
           const newVersion = process.env.new_version;
           const branchName = `release-${newVersion}`;
           const title = `Release ${newVersion}`;
-          const body = '## Changelog\n<!-- markdown-changelog-generator -->';
+          let body = '## Changelog\n';
           const base = 'main';
           const labels = ['pre-release'];
+
+          // Fetch commits for the pull request
+          const compareResponse = await github.rest.repos.compareCommits({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            base: base,
+            head: branchName
+          });
+          const commits = compareResponse.data.commits;
+          body += commits.map(commit => `- ${commit.commit.message} (${commit.sha})`).join('\n') + '\n';
 
           const headRef = await github.rest.git.createRef({
             ...context.repo,


### PR DESCRIPTION
…s changelog.

# Aider chat conversation:

USER:

RequestError [HttpError]: Resource not accessible by integration
    at /home/runner/work/_actions/actions/github-script/v6/dist/index.js:6842:21
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
Error: Unhandled error: HttpError: Resource not accessible by integration
    at async eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:15143:16), <anonymous>:10:17)
    at async main (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:15236:20) {
  status: 403,
  response: {
    url: 'https://api.github.com/repos/djh00t/module_klingon_serial/git/refs',
    status: 403,
    headers: {
      'access-control-allow-origin': '*',
      'access-control-expose-headers': 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset',
      connection: 'close',
      'content-encoding': 'gzip',
      'content-security-policy': "default-src 'none'",
      'content-type': 'application/json; charset=utf-8',
      date: 'Sun, 31 Mar 2024 14:37:55 GMT',
      'referrer-policy': 'origin-when-cross-origin, strict-origin-when-cross-origin',
      server: 'GitHub.com',
      'strict-transport-security': 'max-age=31536000; includeSubdomains; preload',
      'transfer-encoding': 'chunked',
      vary: 'Accept-Encoding, Accept, X-Requested-With',
      'x-accepted-github-permissions': 'contents=write; contents=write,workflows=write',
      'x-content-type-options': 'nosniff',
      'x-frame-options': 'deny',
      'x-github-api-version-selected': '2022-11-28',
      'x-github-media-type': 'github.v3; format=json',
      'x-github-request-id': '04C1:1AF8:5066FF:832E5D:66097543',
      'x-ratelimit-limit': '5000',
      'x-ratelimit-remaining': '4999',
      'x-ratelimit-reset': '1711899475',
      'x-ratelimit-resource': 'core',
      'x-ratelimit-used': '1',
      'x-xss-protection': '0'
    },
    data: {
      message: 'Resource not accessible by integration',
      documentation_url: 'https://docs.github.com/rest/git/refs#create-a-reference'
    }
  },
  request: {
    method: 'POST',
    url: 'https://api.github.com/repos/djh00t/module_klingon_serial/git/refs',
    headers: {
      accept: 'application/vnd.github.v3+json',
      'user-agent': 'actions/github-script octokit-core.js/3.6.0 Node.js/16.20.2 (linux; x64)',
      authorization: 'token [REDACTED]',
      'content-type': 'application/json; charset=utf-8'
    },
    body: '{"ref":"refs/heads/release-0.3.13","sha":"09a58b3082c6550759004ed1444302fa21e6bbb4"}',
    request: { agent: [Agent], hook: [Function: bound bound register] }
  }
}

ASSISTANT: The error message you're encountering indicates that the GitHub Actions script does not have the necessary permissions to create a reference in the repository. This is typically due to the `GITHUB_TOKEN` used by the `github-script` action not having the required scopes.

To resolve this issue, you need to ensure that the `GITHUB_TOKEN` has the correct permissions. By default, the `GITHUB_TOKEN` provided by GitHub Actions has a limited set of permissions for security reasons. However, for operations such as creating a reference, you might need to adjust the permissions.

Here's what you can do:

1. Go to your repository settings on GitHub.
2. Navigate to the "Actions" tab.
3. Under "General," look for "Workflow permissions."
4. Change the workflow permissions to "Read and write permissions."

If you've already done this and the error persists, it could be an issue with the way the `GITHUB_TOKEN` is being used within the script. In that case, you might need to review the script to ensure it's using the token correctly.

Since the `.github/workflows/openfaas-pre-docker-build-pr.yaml` file is the only one marked as *read-write*, I can provide a diff to update the script to include error handling, which will help in debugging the issue further. However, if the problem is related to the token's permissions, the repository settings will need to be updated outside of the code.

Would you like me to provide a diff for improved error handling in the GitHub Actions script?

USER: Make the changelog contain the commit string for each commit in the PR

ASSISTANT: To include the commit string for each commit in the pull request's changelog, we need to modify the GitHub Actions workflow file to fetch the list of commits associated with the pull request and format them into the changelog. Here's the diff to update the `.github/workflows/openfaas-pre-docker-build-pr.yaml` file:

```diff
--- .github/workflows/openfaas-pre-docker-build-pr.yaml
+++ .github/workflows/openfaas-pre-docker-build-pr.yaml
@@ ... @@
    - name: Create or update PR with new release number
      uses: actions/github-script@v6
      with:
        script: |
          const newVersion = process.env.new_version;
          const branchName = `release-${newVersion}`;
          const title = `Release ${newVersion}`;
-         const body = '## Changelog\n<!-- markdown-changelog-generator -->';
+         let body = '## Changelog\n';
          const base = 'main';
          const labels = ['pre-release'];

+         // Fetch commits for the pull request
+         const compareResponse = await github.rest.repos.compareCommits({
+           owner: context.repo.owner,
+           repo: context.repo.repo,
+           base: base,
+           head: branchName
+         });
+         const commits = compareResponse.data.commits;
+         body += commits.map(commit => `- ${commit.commit.message} (${commit.sha})`).join('\n') + '\n';
+
          const headRef = await github.rest.git.createRef({
            ...context.repo,
            ref: `refs/heads/${branchName}`,
            sha: context.sha
          });
          console.log(`Created ref ${headRef.data.ref}`);

          const pullRequest = await github.rest.pulls.create({
            ...context.repo,
            title,
            body,
            head: branchName,
            base,
            labels,
            draft: false
          });
          console.log(`Created pull request #${pullRequest.data.number}`);
      env:
        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
```

This diff adds code to the GitHub Actions script to fetch the commits between the base branch (`main`) and the head branch (`release-${newVersion}`), and then formats them into a changelog that is included in the body of the pull request. Each commit is listed with its message and SHA. Please apply this patch to the workflow file and push the changes to the repository.