### PR TITLE
Fix code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/openfaas/handler.py
+++ b/openfaas/handler.py
@@ -59,7 +59,9 @@ async def health():
         else:
             raise Exception("The / endpoint did not return a valid response.")
     except Exception as e:
-        return {"status": "error", "message": str(e)}, 500
+        import logging
+        logging.error("An error occurred in the /health endpoint", exc_info=True)
+        return {"status": "error", "message": "An internal error has occurred."}, 500
 
 
 @app.get("/favicon.ico")


### PR DESCRIPTION
Fixes [https://github.com/djh00t/module_klingon_serial/security/code-scanning/1](https://github.com/djh00t/module_klingon_serial/security/code-scanning/1)

To fix the problem, we should avoid returning the exception message directly to the user. Instead, we can log the exception on the server side and return a generic error message to the user. This approach ensures that sensitive information is not exposed while still allowing developers to diagnose issues using the server logs.

- Modify the exception handling in the `/health` endpoint to log the exception and return a generic error message.
- Add an appropriate logging mechanism if not already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
